### PR TITLE
allow for pdf mimetype transcripts.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -20,7 +20,7 @@ function islandora_transcript_view(AbstractObject $object) {
     $viewer = islandora_get_viewer(array('dsid' => 'TRANSCRIPT'), 'islandora_pdf_viewers', $object);
     return array(
       'transcript' => array(
-        '#markup' => '<pre>' . $viewer ? $viewer : '' . '</pre>',
+        '#markup' => sprintf('<pre>%s</pre>', $viewer ? $viewer : ''),
       ),
     );
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -15,12 +15,23 @@
  *   A renderable array representing the tab.
  */
 function islandora_transcript_view(AbstractObject $object) {
-  $transcript = $object['TRANSCRIPT']->content;
-  return array(
-    'transcript' => array(
-      '#markup' => '<pre>' . wordwrap($transcript) . '</pre>',
-    ),
-  );
+  if ($object['TRANSCRIPT']->mimetype == 'application/pdf') {
+    module_load_include('inc', 'islandora', 'includes/solution_packs');
+    $viewer = islandora_get_viewer(array('dsid' => 'TRANSCRIPT'), 'islandora_pdf_viewers', $object);
+    return array(
+      'transcript' => array(
+        '#markup' => '<pre>' . $viewer ? $viewer : '' . '</pre>',
+      ),
+    );
+  }
+  else {
+    $transcript = $object['TRANSCRIPT']->content;
+    return array(
+      'transcript' => array(
+        '#markup' => '<pre>' . wordwrap($transcript) . '</pre>',
+      ),
+    );
+  }
 }
 
 /**

--- a/islandora_transcript.module
+++ b/islandora_transcript.module
@@ -46,7 +46,10 @@ function islandora_transcript_menu() {
  *   otherwise.
  */
 function islandora_transcript_view_access($object) {
-  return is_object($object) && isset($object['TRANSCRIPT']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['TRANSCRIPT']);
+  $check = is_object($object)
+           && isset($object['TRANSCRIPT'])
+           && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['TRANSCRIPT']);
+  return $check;
 }
 
 /**
@@ -64,8 +67,11 @@ function islandora_transcript_view_access($object) {
  *   otherwise.
  */
 function islandora_transcript_edit_access($object) {
-  $is_pdf = $object['TRANSCRIPT']->mimetype == 'application/pdf';
-  return !$is_pdf && is_object($object) && isset($object['TRANSCRIPT']) && islandora_datastream_access(ISLANDORA_METADATA_EDIT, $object['TRANSCRIPT']);
+  $check = is_object($object)
+           && isset($object['TRANSCRIPT'])
+           && islandora_datastream_access(ISLANDORA_METADATA_EDIT, $object['TRANSCRIPT'])
+           && ($object['TRANSCRIPT']->mimetype !== 'application/pdf');
+  return $check;
 }
 
 /**

--- a/islandora_transcript.module
+++ b/islandora_transcript.module
@@ -64,7 +64,8 @@ function islandora_transcript_view_access($object) {
  *   otherwise.
  */
 function islandora_transcript_edit_access($object) {
-  return is_object($object) && isset($object['TRANSCRIPT']) && islandora_datastream_access(ISLANDORA_METADATA_EDIT, $object['TRANSCRIPT']);
+  $is_pdf = $object['TRANSCRIPT']->mimetype == 'application/pdf';
+  return !$is_pdf && is_object($object) && isset($object['TRANSCRIPT']) && islandora_datastream_access(ISLANDORA_METADATA_EDIT, $object['TRANSCRIPT']);
 }
 
 /**


### PR DESCRIPTION
# What does this Pull Request do?
Handles PDF datastreams. Disables "Edit Transcript" tab when `$object['TRANSCRIPT']` is PDF.

# What's new?
`islandora_transcript_view` now fetches the pdf viewer when mimetype is 'application/pdf'.

Checks mimetype in `islandora_transcript_edit_access` and disables 'edit' tab for PDF TRANSCRIPTs.

# How should this be tested?
With islandora_transcript enabled, add the TRANSCRIPT datastream to an object, and upload a PDF.
Ensure that 'Edit Transcript' tab is not present when viewing the object.
Ensure that the PDF loads when you click on the transcript tab.

# Additional Notes:

# Interested parties

